### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Config/INI.pm
+++ b/lib/Config/INI.pm
@@ -1,6 +1,6 @@
 use v6;
 
-module Config::INI;
+unit module Config::INI;
 
 grammar INI {
     token TOP      { 

--- a/lib/Config/INI/Writer.pm
+++ b/lib/Config/INI/Writer.pm
@@ -1,6 +1,6 @@
 use v6;
 
-module Config::INI::Writer;
+unit module Config::INI::Writer;
 
 our sub dump (%what) {
     my $ret;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.