### PR TITLE
Support comments starting with '#' next to ';'

### DIFF
--- a/lib/Config/INI.pm
+++ b/lib/Config/INI.pm
@@ -3,11 +3,11 @@ use v6;
 unit module Config::INI;
 
 grammar INI {
-    token TOP      { 
+    token TOP      {
                         ^
                         <.eol>*
                         <toplevel>?
-                        <sections>* 
+                        <sections>*
                         <.eol>*
                         $
                    }
@@ -15,14 +15,14 @@ grammar INI {
     token sections { <header> <keyval>* }
     token header   { ^^ \h* '[' ~ ']' $<text>=<-[ \] \n ]>+ \h* <.eol>+ }
     token keyval   { ^^ \h* <key> \h* '=' \h* <value>? \h* <.eol>+ }
-    regex key      { <![\[]> <-[;=]>+ }
+    regex key      { <![#\[]> <-[;=]>+ }
     regex value    { [ <![;]> \N ]+ }
     # TODO: This should be just overriden \n once Rakudo implements it
-    token eol      { [ ';' \N+ ]? \n }
+    token eol      { [ <[#;]> \N+ ]? \n }
 }
 
 class INI::Actions {
-    method TOP ($/) { 
+    method TOP ($/) {
         my %hash = $<sections>».ast;
         %hash<_> = $<toplevel>.ast.hash if $<toplevel>.?ast;
         make %hash;

--- a/lib/Config/INI.pm
+++ b/lib/Config/INI.pm
@@ -16,7 +16,7 @@ grammar INI {
     token header   { ^^ \h* '[' ~ ']' $<text>=<-[ \] \n ]>+ \h* <.eol>+ }
     token keyval   { ^^ \h* <key> \h* '=' \h* <value>? \h* <.eol>+ }
     regex key      { <![#\[]> <-[;=]>+ }
-    regex value    { [ <![;]> \N ]+ }
+    regex value    { [ <![#;]> \N ]+ }
     # TODO: This should be just overriden \n once Rakudo implements it
     token eol      { [ <[#;]> \N+ ]? \n }
 }

--- a/t/01-parser.t
+++ b/t/01-parser.t
@@ -65,7 +65,7 @@ is %fo<more><optimized>, 'fun', '4.5 ok';
 is %fo<more><dragon>, 'storm', '4.6 ok';
 
 my $fifth = Q {
-    emptykey = 
+    emptykey =
     another = withvalue
 
     [section with space]
@@ -160,9 +160,10 @@ my %te = Config::INI::parse_file($tenth);
 pass 'tenth config (file) parsed';
 is-deeply %te, {
     '_' => {
-        foo => 'comma, separated, values',
-        ano => 'ther',
-        ki  => 'waliu',
-        asd => 'esd'
+        foo         => 'comma, separated, values',
+        ano         => 'ther',
+        ki          => 'waliu',
+        asd         => 'esd',
+        hashcomment => 'before'
     }
 };

--- a/t/test00.ini
+++ b/t/test00.ini
@@ -3,3 +3,5 @@ ano = ther ;as
 ki =waliu; comments are working, derp
 
 asd= esd
+# hashcomment
+hashcomment = before #after


### PR DESCRIPTION
Hi,

On UNIX (-like) systems is it customary to support comments starting with '#' instead of ';' for config INI files. This PR adds support for discarding lines starting with # as comments.

C.

