### PR TITLE
Allow comment lines with no comments

### DIFF
--- a/lib/Config/INI.pm
+++ b/lib/Config/INI.pm
@@ -18,7 +18,7 @@ grammar INI {
     regex key      { <![#\[]> <-[;=]>+ }
     regex value    { [ <![#;]> \N ]+ }
     # TODO: This should be just overriden \n once Rakudo implements it
-    token eol      { [ <[#;]> \N+ ]? \n }
+    token eol      { [ <[#;]> \N* ]? \n }
 }
 
 class INI::Actions {

--- a/t/01-parser.t
+++ b/t/01-parser.t
@@ -29,6 +29,7 @@ is %s<_><foo>, 'bar', '2.1 ok';
 is %s<_><some>, 'thing', '2.2 ok';
 
 my $third = Q {
+;
     foo = bar ; comment
     another= thing;commie
 };


### PR DESCRIPTION
A line can start with ; or # but have nothing afterwards.  Previously
it would simply not parse the file, now it works like any other
comment.

Resolves issue #13.